### PR TITLE
feat: Add env_vars GH_AUTH_TOKEN to deploy step.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,5 +26,5 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           flags: --allow-unauthenticated --timeout 1800
           env_vars: |
-            GH_AUTH_TOKEN=${{ secrets.GH_ACCESS_TOKEN }}
+            GH_AUTH_TOKEN=${{ secrets.GH_AUTH_TOKEN }}
           source: .

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,4 +25,6 @@ jobs:
           region: ${{ secrets.GCP_CLOUDRUN_SERVICE_REGION }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           flags: --allow-unauthenticated --timeout 1800
+          env_vars: |
+            GH_AUTH_TOKEN=${{ secrets.GH_ISSUE_FINDER_TOKEN }}
           source: .

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,5 +26,5 @@ jobs:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           flags: --allow-unauthenticated --timeout 1800
           env_vars: |
-            GH_AUTH_TOKEN=${{ secrets.GH_ISSUE_FINDER_TOKEN }}
+            GH_AUTH_TOKEN=${{ secrets.GH_ACCESS_TOKEN }}
           source: .

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Example response:
    - `GCP_CLOUDRUN_SERVICE_NAME`: The name of the cloud run service, you can select any name that you prefer
    - `GCP_CLOUDRUN_SERVICE_REGION`: The [region](https://cloud.google.com/compute/docs/regions-zones) in the GCP that you want to create the cloud run service
    - `GCP_SA_KEY`: The key that you created for your service account with the permissions to deploy the app. This is a JSON object and should be used as-is
-   - `GH_ACCESS_TOKEN`: The Github Personal Access Token created in the last step.
+   - `GH_AUTH_TOKEN`: The Github Personal Access Token created in the last step.
 
 After the steps above have been completed, go to `Actions` in your GitHub repo and run the CD workflow located in `.git/workflows/cd.yml`. The file is already configured with the action to deploy the cloud run service using the secrets that were created.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Example response:
    - `GCP_CLOUDRUN_SERVICE_NAME`: The name of the cloud run service, you can select any name that you prefer
    - `GCP_CLOUDRUN_SERVICE_REGION`: The [region](https://cloud.google.com/compute/docs/regions-zones) in the GCP that you want to create the cloud run service
    - `GCP_SA_KEY`: The key that you created for your service account with the permissions to deploy the app. This is a JSON object and should be used as-is
-   - `GH_ISSUER_FINDER_PAT`: The Github Personal Access Token created in the last step.
+   - `GH_ACCESS_TOKEN`: The Github Personal Access Token created in the last step.
 
 After the steps above have been completed, go to `Actions` in your GitHub repo and run the CD workflow located in `.git/workflows/cd.yml`. The file is already configured with the action to deploy the cloud run service using the secrets that were created.
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ Example response:
 2. Create a key for the service account, this key will be configured as a secret in the GitHub actions to be able to deploy the app
 3. For the service account, [grant the permissions "Service Account User", "Cloud Run Admin", "Storage Admin"](https://github.com/google-github-actions/deploy-cloudrun) and "Cloud Build Service Account", this last permission is necessary since cloud build will be used to build the image based on the source code directly
 4. Clone this repo to your GitHub account
-5. In the `Settings` of your GitHub repo, go to `Secrets` and create the `New repository secret` with the names and values below:
+5. Create a [Github Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) with `repo: public_repo` scope. Copy this token for use in the next step.
+6. In the `Settings` of your GitHub repo, go to `Secrets` and create the `New repository secret` with the names and values below:
    - `GCP_PROJECT_ID`: The [ID](https://support.google.com/googleapi/answer/7014113?hl=en) of the GCP project as found in your GCP Account
    - `GCP_CLOUDRUN_SERVICE_NAME`: The name of the cloud run service, you can select any name that you prefer
    - `GCP_CLOUDRUN_SERVICE_REGION`: The [region](https://cloud.google.com/compute/docs/regions-zones) in the GCP that you want to create the cloud run service
    - `GCP_SA_KEY`: The key that you created for your service account with the permissions to deploy the app. This is a JSON object and should be used as-is
+   - `GH_ISSUER_FINDER_PAT`: The Github Personal Access Token created in the last step.
 
 After the steps above have been completed, go to `Actions` in your GitHub repo and run the CD workflow located in `.git/workflows/cd.yml`. The file is already configured with the action to deploy the cloud run service using the secrets that were created.
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
#### Description

- Update github workflow for deployment to include env_vars `GH_AUTH_TOKEN` that reads the token from the repos secrets.
- Update readme to add step for creating Github Personal Access Token

#### Notes
- Personal access tokens can only be created for a specific user. There isn't a way to create org level personal access tokens to use with the GitHub api. The scope of this should be limited to read public repositories only.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
