### PR TITLE
fix: use new husky install prepare npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "tap test.js",
+    "prepare": "husky",
     "start": "node ."
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "tap test.js",
-    "prepare": "npx husky install",
     "start": "node ."
   },
   "repository": {


### PR DESCRIPTION
husky does not need the install call, as it seems. 