### PR TITLE
chore: migrate to esm

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -1,11 +1,9 @@
-'use strict'
+import fastify from 'fastify'
 
-const fastify = require('fastify')
+import { fetchIssues as defaultFetchIssues, getGithubClient as defaultGetGithubClient } from './fetch-issues.mjs'
+import { createCache } from 'async-cache-dedupe'
 
-const { fetchIssues: defaultFetchIssues, getGithubClient: defaultGetGithubClient } = require('./fetchIssues')
-const { createCache } = require('async-cache-dedupe')
-
-function build (opts) {
+export async function build (opts) {
   const app = fastify(opts)
   const cache = createCache({
     ttl: 5 * 60, // 5 minutes
@@ -22,7 +20,7 @@ function build (opts) {
     ...opts
   }
 
-  app.register(require('@fastify/cors'), {})
+  app.register(await import('@fastify/cors'), {})
 
   cache.define('fetchIssues', async ({ includeBody, labels, org }) => {
     return await fetchIssues(includeBody, labels, org, getGithubClient())
@@ -74,5 +72,3 @@ function build (opts) {
   })
   return app
 }
-
-module.exports = build

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
-'use strict'
+import neostandard from 'neostandard'
 
-module.exports = require('neostandard')({
-  ignores: require('neostandard').resolveIgnoresFromGitignore(),
+export default neostandard({
+  ignores: (await import('neostandard')).resolveIgnoresFromGitignore(),
   ts: true
 })

--- a/fetch-issues.mjs
+++ b/fetch-issues.mjs
@@ -1,6 +1,4 @@
-'use strict'
-
-const { Octokit } = require('@octokit/rest')
+import { Octokit } from '@octokit/rest'
 
 /* c8 ignore start */
 const getGithubClient = () => {
@@ -53,4 +51,4 @@ const fetchIssues = async (includeBody, labels, org, client) => {
   return Array.from(dedupeMap.values())
 }
 
-module.exports = { fetchIssues, getGithubClient }
+export { fetchIssues, getGithubClient }

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "gh-issues-finder",
   "version": "1.0.0",
   "description": "Tool to help find issues hat you can contribute to",
-  "main": "server.js",
-  "type": "commonjs",
+  "main": "server.mjs",
+  "type": "module",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/server.mjs
+++ b/server.mjs
@@ -1,6 +1,6 @@
-'use strict'
+import { build } from './app.mjs'
 
-const server = require('./app')({
+const server = await build({
   logger: true
 })
 

--- a/test.mjs
+++ b/test.mjs
@@ -1,7 +1,5 @@
-'use strict'
-
-const { test } = require('node:test')
-const { fetchIssues } = require('./fetchIssues')
+import { test } from 'node:test'
+import { fetchIssues } from './fetch-issues.mjs'
 
 const mockIssue = {
   url: 'https://api.github.com/repos/fastify/help/issues/478',
@@ -107,8 +105,8 @@ test('tests the "/api/find-issues" route', async t => {
     }
   }
 
-  const build = require('./app')
-  const app = build({
+  const { build } = await import('./app.mjs')
+  const app = await build({
     fetchIssues,
     getGithubClient: () => {
       return {


### PR DESCRIPTION
Octokit is esm only. Also i dont understand why the CI automerged the octokit upgrade PR. But well, this solves it.