### PR TITLE
ci: check dependabot prs originate from repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
     name: Automerge Dependabot PRs
     if: >
         github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
         github.event.pull_request.user.login == 'dependabot[bot]'
     needs: test
     permissions:


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/6330. This is a batch PR created by a script. Please review prior to merging.